### PR TITLE
Enable reading compressed data blocks

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: '8'
+          java-version: '11'
           distribution: 'zulu'
           cache: 'maven'
       - name: Set up CI environment

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: '8'
+          java-version: '11'
           distribution: 'zulu'
           cache: 'maven'
       - name: Set up CI environment

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .project
 .settings
 .DS_Store
+.idea
+.vscode
 build
 emailable-report.html
 index.html

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>26.0.0</version>
+		<version>44.0.0</version>
 		<relativePath />
 	</parent>
 

--- a/src/main/java/io/scif/lifesci/SDTFormat.java
+++ b/src/main/java/io/scif/lifesci/SDTFormat.java
@@ -37,13 +37,19 @@ import io.scif.config.SCIFIOConfig;
 import io.scif.img.axes.SCIFIOAxes;
 import io.scif.util.FormatTools;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.zip.ZipInputStream;
+
+import org.scijava.io.handle.DataHandleInputStream;
 
 import net.imagej.axis.Axes;
 import net.imagej.axis.CalibratedAxis;
 import net.imglib2.Interval;
 
+import org.scijava.io.handle.BytesHandle;
 import org.scijava.io.handle.DataHandle;
+import org.scijava.io.location.BytesLocation;
 import org.scijava.io.location.Location;
 import org.scijava.plugin.Plugin;
 import org.scijava.util.Bytes;
@@ -297,7 +303,6 @@ public class SDTFormat extends AbstractFormat {
 				getHandle().seek(tmpOff);
 				info.readBlockHeader(getHandle());
 				// Compute channel + block indices from the requested plane index.
-				final int channelIndex = (int) (planeIndex % info.noOfDataBlocks);
 				final int blockIndex = (int) (planeIndex / info.noOfDataBlocks);
 				// Seek to the data block for this plane index
 				for (int i = 0; i < blockIndex; i++) {
@@ -305,9 +310,6 @@ public class SDTFormat extends AbstractFormat {
 					getHandle().seek(tmpOff);
 					info.readBlockHeader(getHandle());
 				}
-				// Skip to the requested plane and row offset
-				getHandle().skip(channelIndex * planeSize + y * paddedWidth * bpp * m
-					.getTimeBins());
 			}
 			// Csarseven support
 			else if (info.noOfDataBlocks > 1) {
@@ -342,23 +344,40 @@ public class SDTFormat extends AbstractFormat {
 					}
 				}
 			}
-			// Standard offset
+			// Standard offset: seek to the block data start; plane/row offset is
+			// applied within the BytesHandle below.
 			else {
-				// binOffset points to the start of the pixels, then we skip the
-				// required number of planes and rows.
-				getHandle().seek(m.getBinOffset() + planeIndex * planeSize + y *
-					paddedWidth * bpp * m.getTimeBins());
+				getHandle().seek(info.dataOffs);
 			}
 
 			// For the SDT subtypes with complete planes per data block, we can read
 			// the requested plane data now.
 			if (info.measMode == 13 || info.noOfDataBlocks == 1) {
-				for (int row = 0; row < h; row++) {
-					getHandle().skipBytes(x * bpp * m.getTimeBins());
-					getHandle().read(b, row * bpp * m.getTimeBins() * w, w * m
-						.getTimeBins() * bpp);
-					getHandle().skipBytes(bpp * m.getTimeBins() * (paddedWidth - x - w));
+				// obtain the data for the current block
+				byte[] bytes;
+				if (info.currentBlockZipped()) {
+					// data is compressed
+					bytes = decompressBlock(info.dataOffs);
+				} else {
+					bytes = new byte[(int) info.blockLength];
+					getHandle().read(bytes);
 				}
+				DataHandle<BytesLocation> handle = new BytesHandle(new BytesLocation(bytes));
+
+				// For FIFO, block navigation already chose the block; skip to the
+				// channel within it. For single-block, skip to the requested plane.
+				final long planeOff = info.measMode == 13
+					? (planeIndex % info.noOfDataBlocks) * (long) planeSize
+					: planeIndex * planeSize;
+				handle.skip(planeOff + y * paddedWidth * bpp * m.getTimeBins());
+				// read in the requested region
+				for (int row = 0; row < h; row++) {
+					handle.skipBytes(x * bpp * m.getTimeBins());
+					handle.read(b, row * bpp * m.getTimeBins() * w, w * m
+						.getTimeBins() * bpp);
+					handle.skipBytes(bpp * m.getTimeBins() * (paddedWidth - x - w));
+				}
+				handle.close();
 			}
 
 			// no pixel merging required
@@ -381,6 +400,27 @@ public class SDTFormat extends AbstractFormat {
 				}
 			}
 			return plane;
+		}
+
+		private byte[] decompressBlock(final long dataOffset) throws IOException {
+			getHandle().seek(dataOffset);
+			try (final ZipInputStream zis = new ZipInputStream(
+				new java.io.FilterInputStream(new DataHandleInputStream<>(getHandle()))
+				{
+
+					@Override
+					public void close() { /* prevent closing the underlying DataHandle */ }
+				}))
+			{
+				zis.getNextEntry();
+				final ByteArrayOutputStream out = new ByteArrayOutputStream();
+				final byte[] tmp = new byte[65536];
+				int n;
+				while ((n = zis.read(tmp)) > 0) {
+					out.write(tmp, 0, n);
+				}
+				return out.toByteArray();
+			}
 		}
 	}
 }

--- a/src/main/java/io/scif/lifesci/SDTFormat.java
+++ b/src/main/java/io/scif/lifesci/SDTFormat.java
@@ -344,25 +344,19 @@ public class SDTFormat extends AbstractFormat {
 					}
 				}
 			}
-			// Standard offset: seek to the block data start; plane/row offset is
-			// applied within the BytesHandle below.
-			else {
-				getHandle().seek(info.dataOffs);
-			}
 
 			// For the SDT subtypes with complete planes per data block, we can read
 			// the requested plane data now.
 			if (info.measMode == 13 || info.noOfDataBlocks == 1) {
+				// Seek to the block data start
+				DataHandle<?> handle = getHandle();
+				handle.seek(info.dataOffs);
 				// obtain the data for the current block
-				byte[] bytes;
 				if (info.currentBlockZipped()) {
-					// data is compressed
-					bytes = decompressBlock(info.dataOffs);
-				} else {
-					bytes = new byte[(int) info.blockLength];
-					getHandle().read(bytes);
+					// data is compressed - we need to decompress it.
+					byte[] bytes = decompressBlock(handle);
+					handle = new BytesHandle(new BytesLocation(bytes));
 				}
-				DataHandle<BytesLocation> handle = new BytesHandle(new BytesLocation(bytes));
 
 				// For FIFO, block navigation already chose the block; skip to the
 				// channel within it. For single-block, skip to the requested plane.
@@ -377,7 +371,9 @@ public class SDTFormat extends AbstractFormat {
 						.getTimeBins() * bpp);
 					handle.skipBytes(bpp * m.getTimeBins() * (paddedWidth - x - w));
 				}
-				handle.close();
+				if (info.currentBlockZipped()) {
+					handle.close();
+				}
 			}
 
 			// no pixel merging required
@@ -402,10 +398,9 @@ public class SDTFormat extends AbstractFormat {
 			return plane;
 		}
 
-		private byte[] decompressBlock(final long dataOffset) throws IOException {
-			getHandle().seek(dataOffset);
+		private static byte[] decompressBlock(DataHandle<?> handle) throws IOException {
 			try (final ZipInputStream zis = new ZipInputStream(
-				new java.io.FilterInputStream(new DataHandleInputStream<>(getHandle()))
+				new java.io.FilterInputStream(new DataHandleInputStream<>(handle))
 				{
 
 					@Override

--- a/src/main/java/io/scif/lifesci/SDTFormat.java
+++ b/src/main/java/io/scif/lifesci/SDTFormat.java
@@ -59,6 +59,7 @@ import org.scijava.util.Bytes;
  * 
  * @author Curtis Rueden
  * @author Mark Hiner
+ * @author Gabriel Selzer
  */
 @Plugin(type = Format.class)
 public class SDTFormat extends AbstractFormat {
@@ -347,39 +348,51 @@ public class SDTFormat extends AbstractFormat {
 			// For the SDT subtypes with complete planes per data block, we can read
 			// the requested plane data now.
 			if (info.measMode == 13 || info.noOfDataBlocks == 1) {
-				// Seek to the block data start
-				DataHandle<?> handle = getHandle();
-				handle.seek(info.dataOffs);
-				// obtain the data for the current block
+				// Seek to the block data start.
+				final DataHandle<?> sourceHandle = getHandle();
+				sourceHandle.seek(info.dataOffs);
+
+				// Obtain the data for the current block.
+				final DataHandle<?> handle;
+				final BytesHandle zipHandle;
 				if (info.currentBlockZipped()) {
-					// data is compressed - we need to decompress it.
-					byte[] bytes = decompressBlock(handle);
-					handle = new BytesHandle(new BytesLocation(bytes));
+					// Data is compressed - we need to decompress it.
+					byte[] bytes = decompressBlock(sourceHandle);
+					// Now read the plane from the decompressed bytes.
+					handle = zipHandle = new BytesHandle(new BytesLocation(bytes));
+				}
+				else {
+					// Read the plane directly from the source handle.
+					handle = sourceHandle;
+					zipHandle = null;
 				}
 
-				// skip to the requested plane
+				// Skip to the requested plane.
 				if (info.measMode == 13) {
-					// FIFO - skip to the requested plane within the current block
+					// FIFO - skip to the requested plane within the current block.
 					handle.skip((planeIndex % info.noOfDataBlocks) * (long) planeSize);
 				}
 				else {
-					// Single-block - skip to the requested plane
+					// Single-block - skip to the requested plane.
 					handle.skip(planeIndex * (long) planeSize);
 				}
 
-				// skip to the requested row
+				// Skip to the requested row.
 				handle.skip(y * paddedWidth * bpp * m.getTimeBins());
 
-				// read in the requested region
+				// Read in the requested region.
 				for (int row = 0; row < h; row++) {
 					handle.skipBytes(x * bpp * m.getTimeBins());
 					handle.read(b, row * bpp * m.getTimeBins() * w, w * m
 						.getTimeBins() * bpp);
 					handle.skipBytes(bpp * m.getTimeBins() * (paddedWidth - x - w));
 				}
-				if (info.currentBlockZipped()) {
-					handle.close();
-				}
+
+				// Clean up the temporary zip handle, if there is one.
+				// This is a no-op for BytesHandle, but closing it here is more correct --
+				// if the underlying code or handle type ever changes, we avoid a future
+				// action-at-a-distance bug waiting to happen.
+				if (zipHandle != null) zipHandle.close();
 			}
 
 			// no pixel merging required

--- a/src/main/java/io/scif/lifesci/SDTFormat.java
+++ b/src/main/java/io/scif/lifesci/SDTFormat.java
@@ -407,8 +407,11 @@ public class SDTFormat extends AbstractFormat {
 					public void close() { /* prevent closing the underlying DataHandle */ }
 				}))
 			{
-				zis.getNextEntry();
-				final ByteArrayOutputStream out = new ByteArrayOutputStream();
+				final java.util.zip.ZipEntry entry = zis.getNextEntry();
+				if (entry == null) {
+					throw new IOException(
+						"Missing ZIP entry in compressed SDT block at offset " + dataOffset);
+				}
 				final byte[] tmp = new byte[65536];
 				int n;
 				while ((n = zis.read(tmp)) > 0) {

--- a/src/main/java/io/scif/lifesci/SDTFormat.java
+++ b/src/main/java/io/scif/lifesci/SDTFormat.java
@@ -357,12 +357,19 @@ public class SDTFormat extends AbstractFormat {
 					handle = new BytesHandle(new BytesLocation(bytes));
 				}
 
-				// For FIFO, block navigation already chose the block; skip to the
-				// channel within it. For single-block, skip to the requested plane.
-				final long planeOff = info.measMode == 13
-					? (planeIndex % info.noOfDataBlocks) * (long) planeSize
-					: planeIndex * planeSize;
-				handle.skip(planeOff + y * paddedWidth * bpp * m.getTimeBins());
+				// skip to the requested plane
+				if (info.measMode == 13) {
+					// FIFO - skip to the requested plane within the current block
+					handle.skip((planeIndex % info.noOfDataBlocks) * (long) planeSize);
+				}
+				else {
+					// Single-block - skip to the requested plane
+					handle.skip(planeIndex * (long) planeSize);
+				}
+
+				// skip to the requested row
+				handle.skip(y * paddedWidth * bpp * m.getTimeBins());
+
 				// read in the requested region
 				for (int row = 0; row < h; row++) {
 					handle.skipBytes(x * bpp * m.getTimeBins());

--- a/src/main/java/io/scif/lifesci/SDTFormat.java
+++ b/src/main/java/io/scif/lifesci/SDTFormat.java
@@ -37,7 +37,6 @@ import io.scif.config.SCIFIOConfig;
 import io.scif.img.axes.SCIFIOAxes;
 import io.scif.util.FormatTools;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.zip.ZipInputStream;
 
@@ -410,14 +409,9 @@ public class SDTFormat extends AbstractFormat {
 				final java.util.zip.ZipEntry entry = zis.getNextEntry();
 				if (entry == null) {
 					throw new IOException(
-						"Missing ZIP entry in compressed SDT block at offset " + dataOffset);
+						"Missing ZIP entry in compressed SDT block");
 				}
-				final byte[] tmp = new byte[65536];
-				int n;
-				while ((n = zis.read(tmp)) > 0) {
-					out.write(tmp, 0, n);
-				}
-				return out.toByteArray();
+				return zis.readAllBytes();
 			}
 		}
 	}

--- a/src/main/java/io/scif/lifesci/SDTInfo.java
+++ b/src/main/java/io/scif/lifesci/SDTInfo.java
@@ -52,9 +52,6 @@ public class SDTInfo {
 	public static final int FIFO_IMAGE_MODE = 13;
 
 	// Block type bit flags (bits 8-15 define data type and compression)
-	public static final int DATA_USHORT = 0x0;      // 16-bit unsigned short
-	public static final int DATA_ULONG = 0x100;     // 32-bit unsigned long
-	public static final int DATA_DBL = 0x200;       // 64-bit double
 	public static final int DATA_ZIPPED = 0x1000;   // data block is compressed
 
 	/** For .set files (setup only). */

--- a/src/main/java/io/scif/lifesci/SDTInfo.java
+++ b/src/main/java/io/scif/lifesci/SDTInfo.java
@@ -51,6 +51,12 @@ public class SDTInfo {
 
 	public static final int FIFO_IMAGE_MODE = 13;
 
+	// Block type bit flags (bits 8-15 define data type and compression)
+	public static final int DATA_USHORT = 0x0;      // 16-bit unsigned short
+	public static final int DATA_ULONG = 0x100;     // 32-bit unsigned long
+	public static final int DATA_DBL = 0x200;       // 64-bit double
+	public static final int DATA_ZIPPED = 0x1000;   // data block is compressed
+
 	/** For .set files (setup only). */
 	public static final String SETUP_IDENTIFIER = "SPC Setup Script File";
 
@@ -861,6 +867,15 @@ public class SDTInfo {
 		measDescBlockNo = stream.readShort();
 		lblockNo = (0xffffffffL & stream.readInt()); // unsigned
 		blockLength = (0xffffffffL & stream.readInt()); // unsigned
+	}
+
+	/**
+	 * Checks if the current block is contained within a zip archive
+	 *
+	 * @return true if bit 12 of blockType is set (DATA_ZIPPED flag)
+	 */
+	public boolean currentBlockZipped() {
+		return (blockType & DATA_ZIPPED) != 0;
 	}
 
 	// -- Helper methods --


### PR DESCRIPTION
This PR augments `SDTFormat` to read compressed data blocks within a SDT file. I carried it to the finish line, taking inspiration from a patch sent to me by @elevans.

Notably, the data blocks are compressed into a ZIP archive, meaning we cannot use e.g. `ZlibCodec` to decompress the data.

The changeset could use a little more scrutiny before merge. For example, I don't fully comprehend all of the skipping going on (which some LLM assistance navigated around). It would also be great to write some unit tests, but there aren't any in this repository yet 😅 